### PR TITLE
New config file

### DIFF
--- a/cmd/server/amqp.go
+++ b/cmd/server/amqp.go
@@ -25,17 +25,14 @@ import (
 
 // confDirPath is defined in main.go
 
-var amqpPass = os.Getenv("AMQP_PASSWORD")
-var amqpHost = os.Getenv("AMQP_HOST")
-var amqpURL = "amqp://guest:" + amqpPass + "@" + amqpHost + ":5672/"
-
 func failOnError(err error, msg string) {
 	if err != nil {
 		log.Fatalf("%s: %s", msg, err)
 	}
 }
 
-func runSubscriber() {
+func runSubscriber(amqpConf *AmqpConfig) {
+	amqpURL := "amqp://" + amqpConf.User + ":" + amqpConf.Password + "@" + amqpConf.Host + ":" + amqpConf.Port + "/"
 	conn, err := amqp.Dial(amqpURL)
 	failOnError(err, "Failed to connect to RabbitMQ")
 	defer conn.Close()

--- a/cmd/server/amqp.go
+++ b/cmd/server/amqp.go
@@ -23,18 +23,19 @@ import (
 	"strings"
 )
 
-// confDirPath is defined in main.go
-
 func failOnError(err error, msg string) {
 	if err != nil {
 		log.Fatalf("%s: %s", msg, err)
 	}
 }
 
-func runSubscriber(amqpConf *AmqpConfig) {
+func runSubscriber(config *Config) {
+	confDirPath := config.Collectd.ConfDir
+	amqpConf := config.Amqp
 	amqpURL := "amqp://" + amqpConf.User + ":" + amqpConf.Password + "@" + amqpConf.Host + ":" + amqpConf.Port + "/"
 	conn, err := amqp.Dial(amqpURL)
 	failOnError(err, "Failed to connect to RabbitMQ")
+
 	defer conn.Close()
 
 	ch, err := conn.Channel()

--- a/cmd/server/api.go
+++ b/cmd/server/api.go
@@ -24,9 +24,8 @@ import (
 	"os"
 )
 
-// confDirPath is defined in main.go
-
-func runAPIServer() {
+func runAPIServer(config *CollectdConfig) {
+	confDirPath := config.ConfDir
 	e := echo.New()
 
 	e.GET("/", func(c echo.Context) error {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"github.com/BurntSushi/toml"
 	"log"
 )
 
@@ -25,12 +26,32 @@ var serverTypeOpt = flag.String("type", "pubsub", "server type: pubsub, api")
 
 const confDirPath = "/etc/collectd/collectd.conf.d/"
 
+// Config is ...
+type Config struct {
+	Amqp AmqpConfig
+}
+
+// AmqpConfig is ...
+type AmqpConfig struct {
+	Host     string
+	User     string
+	Password string
+	Port     string
+}
+
 func main() {
+
+	var config Config
+	_, err := toml.DecodeFile("../../config/config.toml", &config)
+	if err != nil {
+		log.Println("read error of amqp config")
+	}
+
 	flag.Parse()
 
 	switch *serverTypeOpt {
 	case "pubsub":
-		runSubscriber()
+		runSubscriber(&config.Amqp)
 	case "api":
 		runAPIServer()
 	default:

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -24,11 +24,10 @@ import (
 
 var serverTypeOpt = flag.String("type", "pubsub", "server type: pubsub, api")
 
-const confDirPath = "/etc/collectd/collectd.conf.d/"
-
 // Config is ...
 type Config struct {
-	Amqp AmqpConfig
+	Amqp     AmqpConfig
+	Collectd CollectdConfig
 }
 
 // AmqpConfig is ...
@@ -39,21 +38,26 @@ type AmqpConfig struct {
 	Port     string
 }
 
+// CollectdConfig is ...
+type CollectdConfig struct {
+	ConfDir string
+}
+
 func main() {
 
 	var config Config
 	_, err := toml.DecodeFile("../../config/config.toml", &config)
 	if err != nil {
-		log.Println("read error of amqp config")
+		log.Println("read error of config file")
 	}
 
 	flag.Parse()
 
 	switch *serverTypeOpt {
 	case "pubsub":
-		runSubscriber(&config.Amqp)
+		runSubscriber(&config)
 	case "api":
-		runAPIServer()
+		runAPIServer(&config.Collectd)
 	default:
 		log.Fatalln("server type is wrong, see help.")
 	}

--- a/cmd/threshold/config_annotate.toml
+++ b/cmd/threshold/config_annotate.toml
@@ -1,0 +1,6 @@
+[redis]
+ipaddress = "localhost"
+port = "6379"
+password = ""
+DB = 0
+

--- a/cmd/threshold/config_evaluate.toml
+++ b/cmd/threshold/config_evaluate.toml
@@ -1,0 +1,14 @@
+[redis]
+ipaddress = "localhost"
+port = "6379"
+password = ""
+DB = 0
+
+[threshold]
+# exceed by exec sudo ping <IP> -i 0.00005 -c 1000 -s 1000
+interval = 5
+min = 1000000
+
+[collectd]
+plugin = "barometer-localagent"
+type = "if-octets-threshold"

--- a/config/config.toml
+++ b/config/config.toml
@@ -1,0 +1,11 @@
+[redis]
+ipaddress = "localhost"
+port = 6379
+password = ""
+DB = 0
+
+[amqp]
+host = "192.168.0.34"
+user = "stackrabbit"
+password = "stackqueue"
+port = "5672"

--- a/config/config.toml
+++ b/config/config.toml
@@ -9,3 +9,6 @@ host = "192.168.0.34"
 user = "stackrabbit"
 password = "stackqueue"
 port = "5672"
+
+[collectd]
+confdir = "/etc/collectd/collectd.conf.d/"

--- a/config/config.toml
+++ b/config/config.toml
@@ -1,8 +1,12 @@
 [redis]
 ipaddress = "localhost"
-port = 6379
+#port = 6379
 password = ""
 DB = 0
+host = "localhost"
+port = "6379"
+#password = ""
+#db = 0
 
 [amqp]
 host = "192.168.0.34"

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -1,0 +1,40 @@
+[common]
+# All daemons share redis DB for annotation etc.
+redis_host = "localhost"
+redis_port = "6379"
+redis_password = ""
+redis_db = 0
+
+
+[server]
+amqp_host = "192.0.2.3"
+amqp_user = "guest"
+amqp_password = "xxxx"
+amqp_port = "5672"
+
+collectd_confdir = "/etc/collectd/collectd.conf.d"
+
+
+[infofetch]
+os_username = "admin"
+os_user_domain_name = "Default"
+os_project_domain_name = ""
+os_project_name = "admin"
+os_password = "xxxx"
+os_auth_url = "http://192.0.2.3:5000/v3"
+
+
+[threshold]
+# redis for raw metrics data
+redis_host = "localhost"
+redis_port = "6379"
+redis_password = ""
+redis_db = 0
+
+# exceed by exec "sudo ping -i 0.00005 -c 1000 -s 1000 -q <IP>"
+interval = 5
+min = 1000000
+
+collectd_plugin = "barometer-localagent"
+collectd_type = "if-octets-threshold"
+


### PR DESCRIPTION
First, please mainly review the new file path and the contents of new config file.
`examples/config.toml`

#28, #31 and #33 are just merged, daemons do not load the new config.

In Barometer repository, the config is put as puppet template.
https://github.com/opnfv/barometer/blob/master/puppet-barometer/templates/collectd.conf.erb
Now, I want to put our config file as an example. (Later, we may change the file to puppet template)

After this pullreq is merged, I will make the following changes.
* Load new configuration file
  * assuming that the new config file is put as /etc/barometer-localagent/config.toml
  * including OpenStack setting
* Fix of #31 comment (log about password setting)

#11 
