### PR TITLE
Cleanup package name

### DIFF
--- a/cmd/infofetch/daemon.go
+++ b/cmd/infofetch/daemon.go
@@ -19,14 +19,14 @@ package main
 import (
 	"context"
 	"github.com/BurntSushi/toml"
-	"github.com/distributed-monitoring/agent/pkg/annotate"
+	"github.com/distributed-monitoring/agent/pkg/common"
 	"github.com/go-redis/redis"
 	libvirt "github.com/libvirt/libvirt-go"
 	"log"
 	"sync"
 )
 
-var infoPool annotate.RedisPool
+var infoPool common.RedisPool
 
 // Config is ...
 type Config struct {
@@ -68,7 +68,7 @@ func main() {
 		Password: config.Common.RedisPassword,
 		DB:       config.Common.RedisDB,
 	})
-	infoPool = annotate.RedisPool{Client: redisClient}
+	infoPool = common.RedisPool{Client: redisClient}
 	// Initialize redis db...
 	infoPool.DelAll()
 

--- a/cmd/threshold/transmit.go
+++ b/cmd/threshold/transmit.go
@@ -19,7 +19,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/distributed-monitoring/agent/pkg/annotate"
+	"github.com/distributed-monitoring/agent/pkg/common"
 	"github.com/go-redis/redis"
 	"strconv"
 	"strings"
@@ -58,7 +58,7 @@ func transmit(config *Config, edlist []evalData) {
 		Password: annoConfig.RedisPassword,
 		DB:       annoConfig.RedisDB,
 	})
-	pool := annotate.RedisPool{Client: client}
+	pool := common.RedisPool{Client: client}
 
 	notifier := collectdNotifier{
 		pluginName: config.Threshold.CollectdPlugin,

--- a/pkg/common/redispool.go
+++ b/pkg/common/redispool.go
@@ -14,14 +14,12 @@
  *   limitations under the License.
  */
 
-package annotate
+package common
 
 import (
 	"github.com/go-redis/redis"
 	"log"
 )
-
-const redisLabel = "barometer-localagent"
 
 // RedisPool is an implementation of Pool by redis.
 type RedisPool struct {

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -14,7 +14,10 @@
  *   limitations under the License.
  */
 
-package annotate
+package common
+
+// redisLabel is prefix of local-agent for redis
+const redisLabel = "barometer-localagent"
 
 // Pool is an interface of DB pool to annotate.
 // e.g. Set("virt_name/instance-00000001", "{"OS-name": "testvm1"}")


### PR DESCRIPTION
This fix addresses #41, rename pkg/annotate to pkg/common, change
annotate.go -> types.go and move redisLabel to types.go.